### PR TITLE
fixes font loading

### DIFF
--- a/lib/loadFont.js
+++ b/lib/loadFont.js
@@ -15,9 +15,8 @@ module.exports = function loadFont(fontPath, callback) {
 
     return opentype.load(path.join(__dirname, '..', fontPath), function (err, font) {
         if (err) {
-            callback(err);
+            return callback(err);
         }
-
         fontCache[fontPath] = font;
         callback(null, font);
     });


### PR DESCRIPTION
issue: if font file does not exist, return with error, current causes main process to stop.
fix: guard the load font function to not fall through if statement. 
# before

<img width="708" alt="screen shot 2016-03-28 at 8 48 07 am" src="https://cloud.githubusercontent.com/assets/1854811/14086639/ddff8842-f4c1-11e5-8f46-4b581a415403.png">
# after

<img width="717" alt="screen shot 2016-03-28 at 8 48 16 am" src="https://cloud.githubusercontent.com/assets/1854811/14086641/e1d98ff8-f4c1-11e5-99e3-0b37d9315455.png">
